### PR TITLE
Simplify QnA prompts and log model inputs

### DIFF
--- a/packages/providers/src/monitoring/langfuse-wrapper.ts
+++ b/packages/providers/src/monitoring/langfuse-wrapper.ts
@@ -1,6 +1,8 @@
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { Embeddings } from '@langchain/core/embeddings';
 import { encode } from 'gpt-tokenizer';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // Try to import TraceManager from observability package if available
 let TraceManager: any = null;
@@ -63,6 +65,28 @@ interface MonitoringConfig {
 let _globalConfig: MonitoringConfig = {
   enabled: false,
 };
+
+/**
+ * Append prompt data to a log file for inspection
+ */
+function logPrompt(
+  input: any,
+  context: { userId?: string; modelId?: string; provider?: string } = {},
+) {
+  try {
+    const logPath = process.env.PROMPT_LOG_PATH || path.resolve(process.cwd(), 'prompt.log');
+    const record = {
+      timestamp: new Date().toISOString(),
+      userId: context.userId,
+      modelId: context.modelId,
+      provider: context.provider,
+      messages: input,
+    };
+    fs.appendFileSync(logPath, `${JSON.stringify(record)}\n`, 'utf8');
+  } catch (error) {
+    console.error('[Providers Monitoring] Failed to write prompt log:', error);
+  }
+}
 
 /**
  * Initialize monitoring with configuration
@@ -184,6 +208,7 @@ export function wrapChatModelWithMonitoring(
     });
 
     try {
+      logPrompt(input, context);
       const result = await originalInvoke(input, options);
 
       // Extract usage data or calculate accurately
@@ -233,6 +258,7 @@ export function wrapChatModelWithMonitoring(
       });
 
       try {
+        logPrompt(input, context);
         const stream = await originalStream(input, options);
 
         // Create a new readable stream that logs the output

--- a/packages/skill-template/src/scheduler/module/commonQnA/prompt.ts
+++ b/packages/skill-template/src/scheduler/module/commonQnA/prompt.ts
@@ -1,13 +1,4 @@
-import { buildContextFormat } from './context';
-import {
-  buildChatHistoryRules,
-  chatHistoryReminder,
-  buildQueryProcessAndChatHistoryInstructions,
-} from '../common/chat-history';
-import { buildQueryPriorityInstruction, buildSpecificQueryInstruction } from '../common/query';
-import { buildContextDisplayInstruction } from '../common/context';
-import { buildCommonQnAExamples, buildCommonQnAChatHistoryExamples } from './examples';
-import { buildCitationRules } from '../common/citationRules';
+import { chatHistoryReminder } from '../common/chat-history';
 import { buildLocaleFollowInstruction } from '../common/locale-follow';
 import {
   buildQueryIntentAnalysisInstruction,
@@ -20,101 +11,19 @@ import {
 } from '../common/personalization';
 
 export const buildNoContextCommonQnASystemPrompt = () => {
-  return `You are an AI assistant developed by Refly. Your task is to provide helpful, accurate, and concise information to users' queries.
+  return `You are Refly, an AI assistant.
 
 ${buildCurrentTimeInfo()}
 
-Guidelines:
-1. ALWAYS directly address the user's specific question
-2. Stay focused on the exact query - don't add unnecessary information
-3. Answer questions directly and concisely
-4. If you're unsure about something, say so
-6. Maintain a friendly and professional tone
-7. Do not ask for or disclose personal information
-
-Query Handling Priority:
-1. Focus exclusively on what the user explicitly asked
-2. Provide direct answers to direct questions
-3. Don't expand scope beyond the original query
-4. If a question is unclear, ask for clarification rather than making assumptions
-
-When appropriate, inform users about your main capabilities:
-1. You can provide more accurate answers if they add context to their queries.
-2. You can search their knowledge base or entire workspace for relevant information.
-3. You can retrieve online information to answer queries.
-4. You can assist with reading comprehension, writing tasks, and general knowledge questions.
-
-Your goal is to provide clear, accurate, and helpful responses to the user's questions, while also guiding them on how to best utilize your capabilities.
-
-${buildSpecificQueryInstruction()}
-`;
+Answer the user's question directly and concisely. If you are unsure, say so.`;
 };
 
 export const buildContextualCommonQnASystemPrompt = () => {
-  const systemPrompt = `You are an advanced AI assistant developed by Refly, specializing in knowledge management, reading comprehension, and answering questions based on context. Your core mission is to help users effectively understand and utilize information.
+  return `You are Refly, an AI assistant.
 
-  ${buildCurrentTimeInfo()}
+${buildCurrentTimeInfo()}
 
-  ## Query Priority and Context Relevance:
-  1. ALWAYS prioritize the user's original query intent above all else
-  2. Context Relevance Assessment:
-     - First determine if the provided context is directly relevant to the user's original query
-     - If the context is NOT relevant to the query, IGNORE the context and answer the query directly
-     - Only use context when it clearly adds value to answering the user's specific question
-  3. Query vs Context Guidelines:
-     - User query about "what is React?" + Context about "Python" => Answer about React, ignore Python context
-     - User query about "how to cook pasta?" + Context about "software development" => Answer cooking question, ignore tech context
-     - User query about "explain this code" + Context with relevant code => Use context to explain the specific code
-
-  ## Role and Capabilities:
-  1. Knowledge Management Expert: You excel at organizing, interpreting, and retrieving information from various sources.
-  2. Reading Comprehension Specialist: You can:
-     - Analyze complex texts and extract key insights
-     - Identify main themes and supporting details
-     - Make logical connections between different pieces of information
-     - Understand both explicit and implicit meanings
-     - Break down complex concepts into simpler components
-  3. Question Answering Expert: You provide:
-     - Precise answers based on available context
-     - Clear explanations of complex topics
-     - Factual responses with proper citations
-     - Logical reasoning for your conclusions
-     - Multiple perspectives when relevant
-
-  ${buildQueryPriorityInstruction()}
-
-  ${buildQueryProcessAndChatHistoryInstructions()}
-
-  ${buildChatHistoryRules()}
-
-  ${buildContextFormat()}
-
-  ${buildCitationRules()}
-
-  ${buildCommonQnAExamples()}
-
-  ${buildCommonQnAChatHistoryExamples()}
-
-
-  ## Guidelines:
-  1. Always maintain a professional, unbiased, and expert tone in your responses.
-  2. Provide detailed and accurate information, citing sources from the given context when applicable.
-  3. If you're unsure about something or if the required information is not in the context, clearly state this and offer to find more information if needed.
-  4. Respect user privacy and confidentiality. Do not ask for or disclose personal information.
-  5. Adapt your language complexity to match the user's level of expertise as inferred from their query and the conversation history.
-  7. Keep your answers direct and to the point. Provide the answer immediately without unnecessary explanations.
-  8. Query Fidelity: Never deviate from the original query's intent
-  9. Context Usage: Only use context that directly relates to the query
-  10. When in doubt, prioritize answering the explicit question over using provided context
-
-  Remember, your goal is to be a knowledgeable, efficient, and user-friendly assistant in all matters related to knowledge comprehension and information processing. Always strive to provide value and enhance the user's understanding of their query and related topics.Consider all relevant context items when addressing user requests, especially when dealing with selected content or context-specific tasks.
-
-  ${buildContextDisplayInstruction()}
-
-  ${buildSpecificQueryInstruction()}
-  `;
-
-  return systemPrompt;
+Use the provided context only when it helps answer the question. If the context is irrelevant, ignore it and respond directly.`;
 };
 
 export const buildCommonQnASystemPrompt = (_locale: string, needPrepareContext: boolean) => {


### PR DESCRIPTION
## Summary
- streamline common QnA system prompts to reduce token usage
- log model inputs to a file for each LLM request

## Testing
- `node_modules/@biomejs/biome/bin/biome lint packages/providers/src/monitoring/langfuse-wrapper.ts packages/skill-template/src/scheduler/module/commonQnA/prompt.ts`
- `pnpm test` *(fails: @refly/openapi-schema@0.8.0 test: `echo "Error: no test specified" && exit 1`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa57d3e50c8324a50c6d5766b59f6a