### PR TITLE
fix(utils): handle falsy values in safeEqual

### DIFF
--- a/packages/utils/src/parse.test.ts
+++ b/packages/utils/src/parse.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { safeEqual } from './parse';
+
+describe('safeEqual', () => {
+  it('should return true for equal values', () => {
+    expect(safeEqual('a', 'a')).toBe(true);
+  });
+
+  it('should handle falsy values correctly', () => {
+    expect(safeEqual('', '')).toBe(true);
+    expect(safeEqual(0, 0)).toBe(true);
+    expect(safeEqual(false, false)).toBe(true);
+  });
+
+  it('should return false when values differ or are nullish', () => {
+    expect(safeEqual('a', 'b')).toBe(false);
+    expect(safeEqual(null, 'a')).toBe(false);
+    expect(safeEqual(undefined, 'a')).toBe(false);
+  });
+});

--- a/packages/utils/src/parse.ts
+++ b/packages/utils/src/parse.ts
@@ -22,8 +22,12 @@ export const safeStringifyJSON = (value: any, errorCallback?: (e: unknown) => st
   }
 };
 
-export const safeEqual = (val1, val2): boolean => {
-  return val1 && val2 && val1 === val2;
+export const safeEqual = (val1: unknown, val2: unknown): boolean => {
+  if (val1 == null || val2 == null) {
+    return false;
+  }
+
+  return val1 === val2;
 };
 
 export function isJSON(variable: any): boolean {


### PR DESCRIPTION
## Summary
- ensure `safeEqual` returns a boolean and handles null/undefined inputs
- add tests covering falsy, equal and mismatched values

## Testing
- `pnpm --filter @refly/utils test:run`
- `pnpm lint packages/utils/src/parse.ts packages/utils/src/parse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa567a74ac8324834c59c6fefaefb7